### PR TITLE
AURO MIGRATION: Update node to v22

### DIFF
--- a/.github/settings.yml
+++ b/.github/settings.yml
@@ -70,7 +70,7 @@ branches:
         # Required. Require branches to be up to date before merging.
         strict: true
         # Required. The list of status checks to require in order to merge into this branch
-        contexts: ["test (18.x)", "test (20.x)", "license/cla"]
+        contexts: ["test (20.x)", "test (22.x)", "license/cla"]
       # Required. Enforce all configured restrictions for administrators. Set to true to enforce required status checks for repository administrators. Set to null to disable.
       enforce_admins: false
       # Required. Restrict who can push to this branch. Team and user restrictions are only available for organization-owned repositories. Set to null to disable.

--- a/.github/workflows/testPublish.yml
+++ b/.github/workflows/testPublish.yml
@@ -1,7 +1,6 @@
 name: Test and publish
 
 # Controls when the action will run. Triggers the workflow on push or pull request
-
 # events but only for the main branch
 on:
   push:
@@ -16,7 +15,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [18.x, 20.x]
+        node-version: [20.x, 22.x]
 
     steps:
       - uses: actions/checkout@v4
@@ -39,7 +38,7 @@ jobs:
           persist-credentials: false
       - uses: actions/setup-node@v4
         with:
-          node-version: 20.x
+          node-version: 22.x
       - run: npm ci
       - run: npm run build:release
       - uses: cycjimmy/semantic-release-action@v4

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@aurodesignsystem/auro-skeleton",
-  "version": "3.1.0",
+  "version": "3.1.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@aurodesignsystem/auro-skeleton",
-      "version": "3.1.0",
+      "version": "3.1.1",
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -60,7 +60,7 @@
         "yaml-lint": "^1.7.0"
       },
       "engines": {
-        "node": "^18.x || ^20.x "
+        "node": "^20.x || ^22.x "
       },
       "peerDependencies": {
         "@aurodesignsystem/design-tokens": "^4.9.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@aurodesignsystem/auro-library": "^3.0.2",
+        "@aurodesignsystem/auro-library": "^3.0.3",
         "chalk": "^5.3.0",
         "lit": "^3.2.1"
       },
@@ -68,9 +68,9 @@
       }
     },
     "node_modules/@aurodesignsystem/auro-library": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/@aurodesignsystem/auro-library/-/auro-library-3.0.2.tgz",
-      "integrity": "sha512-U3DQf0ah6FcJCb4w/XIoKiemg1XPuQCAstQI0juFSAjUQ8Ix3SaJTPwdKomg6legGR+YTFmrNk+ZeJRYJ5aE0g==",
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@aurodesignsystem/auro-library/-/auro-library-3.0.3.tgz",
+      "integrity": "sha512-Vr+ICwv1u8QbwHin7/QxWZU9FmQYzWChIqKYqqUo+Z4hWOfJbeebYbyZjiqAANeluzodwUa5ocJ8gMm430A1fQ==",
       "license": "Apache-2.0",
       "dependencies": {
         "handlebars": "^4.7.8",
@@ -81,7 +81,7 @@
         "generateDocs": "bin/generateDocs.mjs"
       },
       "engines": {
-        "node": "^18 || ^20"
+        "node": "^20.x || ^22.x"
       }
     },
     "node_modules/@aurodesignsystem/design-tokens": {

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
   "main": "index.js",
   "license": "Apache-2.0",
   "engines": {
-    "node": "^18.x || ^20.x "
+    "node": "^20.x || ^22.x "
   },
   "dependencies": {
     "@aurodesignsystem/auro-library": "^3.0.2",

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "node": "^20.x || ^22.x "
   },
   "dependencies": {
-    "@aurodesignsystem/auro-library": "^3.0.2",
+    "@aurodesignsystem/auro-library": "^3.0.3",
     "chalk": "^5.3.0",
     "lit": "^3.2.1"
   },


### PR DESCRIPTION
Resolves AlaskaAirlines/auro-templates#6

## Summary by Sourcery

Update Node to v22 and migrate to Auro library v3.

Enhancements:
- Remove graphiteWidth option for performance reasons.
- Update repository settings to remove description and update topics.
- Update team permissions to grant admin access to auro-team and push access to nonauroteamwriteaccess.
- Update contributing guidelines with information about conventional commits and rebasing.
- Add a workflow to deploy a demo on pull requests to the main branch.

Build:
- Update Node version to v22 in the project configuration.

CI:
- Update CI workflows to test against Node 20 and 22.

Tests:
- Update test matrix in CI to include Node version 22.