### PR TITLE
`auro migration` update all repos to use Auro WCSS 6.0.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@aurodesignsystem/auro-skeleton",
-  "version": "3.1.1",
+  "version": "3.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@aurodesignsystem/auro-skeleton",
-      "version": "3.1.1",
+      "version": "3.2.0",
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -17,7 +17,7 @@
       "devDependencies": {
         "@aurodesignsystem/design-tokens": "^4.10.0",
         "@aurodesignsystem/eslint-config": "^1.3.2",
-        "@aurodesignsystem/webcorestylesheets": "^5.1.2",
+        "@aurodesignsystem/webcorestylesheets": "^6.0.1",
         "@commitlint/cli": "^19.5.0",
         "@commitlint/config-conventional": "^19.5.0",
         "@open-wc/testing": "^4.0.0",
@@ -64,7 +64,7 @@
       },
       "peerDependencies": {
         "@aurodesignsystem/design-tokens": "^4.9.2",
-        "@aurodesignsystem/webcorestylesheets": "^5.1.2"
+        "@aurodesignsystem/webcorestylesheets": "^6.0.1"
       }
     },
     "node_modules/@aurodesignsystem/auro-library": {
@@ -234,20 +234,19 @@
       }
     },
     "node_modules/@aurodesignsystem/webcorestylesheets": {
-      "version": "5.1.2",
-      "resolved": "https://registry.npmjs.org/@aurodesignsystem/webcorestylesheets/-/webcorestylesheets-5.1.2.tgz",
-      "integrity": "sha512-pokV/Mf83oOCac8jjFjqjaHxWoaMrakPVxgpdG6eVSd3Tj5EiMjb3DlYGzOpl57R+s026gJtqfwdAPoj23b3og==",
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/@aurodesignsystem/webcorestylesheets/-/webcorestylesheets-6.0.1.tgz",
+      "integrity": "sha512-Q+bD0zio8dRUjSgRFBeuHmV6mSfQuLVpF+obDC0XCDcD7mbzXqJjRM/vEexy7soX4R/lsu1fKcngolgtC3Nr4g==",
       "dev": true,
       "hasInstallScript": true,
-      "license": "Apache-2.0",
       "dependencies": {
-        "chalk": "^5.3.0"
+        "chalk": "^5.4.1"
       },
       "engines": {
-        "node": "^18 || ^20"
+        "node": "^20 || ^22"
       },
       "peerDependencies": {
-        "@aurodesignsystem/design-tokens": "^4.1.1",
+        "@aurodesignsystem/design-tokens": "^4.9.1",
         "sass": "^1.42.1"
       }
     },
@@ -3945,10 +3944,9 @@
       }
     },
     "node_modules/chalk": {
-      "version": "5.3.0",
-      "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.3.0.tgz",
-      "integrity": "sha512-dLitG79d+GV1Nb/VYcCDFivJeK1hiukt9QjRNVOsUtTy1rR1YJsmpGGTZ3qJos+uw7WmWF4wUwBd9jxjocFC2w==",
-      "license": "MIT",
+      "version": "5.4.1",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.4.1.tgz",
+      "integrity": "sha512-zgVZuo2WcZgfUEmsn6eO3kINexW8RAE4maiQ8QNs8CtpPCSyMiYsULR3HQYkm3w8FIA3SberyMJMSldGsW+U3w==",
       "engines": {
         "node": "^12.17.0 || ^14.13 || >=16.0.0"
       },

--- a/package.json
+++ b/package.json
@@ -26,12 +26,12 @@
   },
   "peerDependencies": {
     "@aurodesignsystem/design-tokens": "^4.9.2",
-    "@aurodesignsystem/webcorestylesheets": "^5.1.2"
+    "@aurodesignsystem/webcorestylesheets": "^6.0.1"
   },
   "devDependencies": {
     "@aurodesignsystem/design-tokens": "^4.10.0",
     "@aurodesignsystem/eslint-config": "^1.3.2",
-    "@aurodesignsystem/webcorestylesheets": "^5.1.2",
+    "@aurodesignsystem/webcorestylesheets": "^6.0.1",
     "@commitlint/cli": "^19.5.0",
     "@commitlint/config-conventional": "^19.5.0",
     "@open-wc/testing": "^4.0.0",


### PR DESCRIPTION
Resolves AlaskaAirlines/auro-cli#30

## Summary by Sourcery

Update Auro Webcore Stylesheets to v6 and Auro Design Tokens to v4.10.0.

Enhancements:
- Upgrade `@aurodesignsystem/webcorestylesheets` from v5.1.2 to v6.0.1.
- Upgrade `@aurodesignsystem/design-tokens` from v4.9.2 to v4.10.0.