### PR TITLE
Force a release based on semantic commit

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,8 +30,8 @@
   },
   "devDependencies": {
     "@aurodesignsystem/design-tokens": "^4.10.0",
-    "@aurodesignsystem/eslint-config": "^1.3.2",
     "@aurodesignsystem/webcorestylesheets": "^6.0.1",
+    "@aurodesignsystem/eslint-config": "^1.3.2",
     "@commitlint/cli": "^19.5.0",
     "@commitlint/config-conventional": "^19.5.0",
     "@open-wc/testing": "^4.0.0",


### PR DESCRIPTION
I goofed up and didn't make my last commit a "feat" or other release trigger keyword, and our auto-release tool rightly didn't do a release.

THIS PR JUST MOVES ONE LINE, IT DOES NOT ADD OR REMOVE ANYTHING :)

## Summary by Sourcery

Chores:
- Move `@aurodesignsystem/eslint-config` dependency in `package.json` after `@aurodesignsystem/webcorestylesheets`.